### PR TITLE
DCT_118 Avoid creating Revision changes entry for model create  opera…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -317,7 +317,7 @@ exports.init = (sequelize, optionsArg) => {
 					.save({ transaction: opt.transaction })
 					.then((objectRevision) => {
 						// Loop diffs and create a revision-diff for each
-						if (options.enableRevisionChangeModel) {
+						if (options.enableRevisionChangeModel && query.operation === 'update') {
 							_.forEach(delta, (difference) => {
 								const o = helpers.diffToString(
 									difference.item


### PR DESCRIPTION
https://idyllwildventures.atlassian.net/browse/DCT-118

I found that  when this library tries to create RevisionChange record for 'db.create' operation that is when the transaction gets locked. For "db.create" operation the "RevisionChanges" entry doesn't have much usage I believe.

So as a quick fix, for now I have put a condition to create Revision Changes only for db.update operation.

**NOTE**:  The RevisionChanges entries are getting created inside a loop. May be we can circle back on this and refactor later. 
